### PR TITLE
Add support for custom stores

### DIFF
--- a/storee.js
+++ b/storee.js
@@ -1,5 +1,29 @@
-export default function storee() {
+export default function storee(options = {}) {
 	const backup = {};
+
+	if (typeof options !== 'undefined' && typeof options !== 'object') {
+		throw new Error('invalid options');
+	}
+
+	const store = (() => {
+		if (typeof options.store === 'undefined') {
+			return window.localStorage;
+		}
+
+		if (typeof options.store !== 'object') {
+			throw new Error('invalid store');
+		}
+
+		if (typeof options.store.setItem !== 'function') {
+			throw new Error('invalid store');
+		}
+
+		if (typeof options.store.getItem !== 'function') {
+			throw new Error('invalid store');
+		}
+
+		return options.store;
+	})();
 
 	const set = (key, value) => {
 		const type = typeof value;
@@ -14,7 +38,7 @@ export default function storee() {
 		}
 
 		try {
-			window.localStorage.setItem(key, parsedValue);
+			store.setItem(key, parsedValue);
 		} catch (e) {
 			backup[key] = parsedValue;
 		}
@@ -23,7 +47,7 @@ export default function storee() {
 	const get = (key) => {
 		const value = (() => {
 			try {
-				const v = window.localStorage.getItem(key);
+				const v = store.getItem(key);
 
 				if (v === null && typeof backup[key] !== 'undefined') {
 					return backup[key];

--- a/tests/index.js
+++ b/tests/index.js
@@ -8,6 +8,20 @@ test('exports a function', (t) => {
 	t.is(typeof storee, 'function');
 });
 
+test('works with default localStorage', (t) => {
+	t.notThrows(() => storee());
+});
+
+test('throws an error on invalid arguments', (t) => {
+	const noop = () => {};
+
+	t.throws(() => storee('sessionStorage'));
+	t.throws(() => storee({ store: 'sessionStorage' }));
+	t.throws(() => storee({ store: { setItem: 'invalid', getItem: noop } }));
+	t.throws(() => storee({ store: { setItem: noop, getItem: 'invalid' } }));
+	t.notThrows(() => storee({ store: { setItem: noop, getItem: noop } }));
+});
+
 test('has a set method', (t) => {
 	const store = storee();
 	t.is(typeof store.set, 'function');


### PR DESCRIPTION
Use `sessionStorage` instead by initializing like this:

```
const store = storee({ store: window.sessionStorage });
```

or use any custom JS object as long as it has a `setItem` and `getItem` method.